### PR TITLE
Update quicklzpy.c: fix compile error on mac

### DIFF
--- a/quicklzpy.c
+++ b/quicklzpy.c
@@ -462,9 +462,9 @@ initquicklz(void)
 {
 
     if (PyType_Ready(&QLZStateCompressType) < 0)
-        return NULL;
+        return ;
     if (PyType_Ready(&QLZStateDecompressType) < 0)
-        return NULL;
+        return ;
 
 #if PY_MAJOR_VERSION >= 3
     PyObject *module = PyModule_Create(&moduledef);


### PR DESCRIPTION
    quicklzpy.c:465:9: error: void function 'initquicklz' should not return a value [-Wreturn-type]
            return NULL;
            ^      ~~~~
    quicklzpy.c:467:9: error: void function 'initquicklz' should not return a value [-Wreturn-type]
            return NULL;